### PR TITLE
Don't install test folder

### DIFF
--- a/box.json
+++ b/box.json
@@ -24,5 +24,8 @@
     "shortDescription":"Utility module for computing function names from source paths and line numbers.",
     "slug":"funclinenums",
     "type":"modules",
-    "version":"1.1.2"
+    "version":"1.1.2",
+    "ignore":[
+        "/tests",
+    ]
 }


### PR DESCRIPTION
The file https://github.com/jcberquist/function-linenums/blob/master/tests/data/input/tagtest.cfc has invalid syntax in it which causes errors when trying to precompile all the CF files in a project for deployment.  This pull sets the tests folder to ignored so it shouldn't install any longer.  